### PR TITLE
ci: :fire: replace label-syncer action

### DIFF
--- a/.github/workflows/label_sync.yml
+++ b/.github/workflows/label_sync.yml
@@ -9,6 +9,10 @@ on:
       - .github/workflows/label_sync.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   label-sync-local:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c #v1.3.0
+      - uses: brpaz/action-label-syncer@32e516ae73bbf7c7c0548897be07080795336e15 #v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -52,7 +56,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c #v1.3.0
+      - uses: brpaz/action-label-syncer@32e516ae73bbf7c7c0548897be07080795336e15 #v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This PR will replace the action-label-syncer with a more current one from another publisher.