### PR TITLE
chore: fix renovate schedule format

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>jfandy1982/.github//renovate-base.json"],
-  "schedule": ["8 4 * * 5"]
+  "schedule": ["after 4am and before 5am on Friday"]
 }


### PR DESCRIPTION
## Summary

- Replace cron expression `8 4 * * 5` with Renovate DSL `after 4am and before 5am on Friday` — cron is silently ignored by Renovate

## Related Issues
Closes #1