### PR TITLE
feat: add housekeeping workflow

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,13 @@
+name: Housekeeping
+
+on:
+  schedule:
+    - cron: '03 04 * * 5'
+  workflow_dispatch:
+
+jobs:
+  retention:
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-retention-workflow-runs.yml@main
+    permissions:
+      actions: write
+      contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ The nested `.github/` structure is intentional: GitHub reads community health fi
 - `renovate-base.json` — shared Renovate base config, extended by all org repos
 - `SECURITY.md` — exists in repo root (work in progress, placeholder content is intentional)
 - `experiments/` — deliberate playground and backup directory, not production code; ignore when reviewing
+  - `experiments/superpowers/` — brainstorming specs and implementation plans from Claude sessions (gitignored, local only); check here for prior design decisions before starting new work
 - `node_modules/` — exists locally but is gitignored; not committed to the repo
 
 ## Tooling


### PR DESCRIPTION
## Summary

- Adds `housekeeping.yml` — local orchestrator for this repo, triggers weekly on Friday and on manual dispatch
- Updates CLAUDE.md to reflect tooling additions

## Notes

- Artifacts are deleted implicitly when their parent workflow run is deleted (GitHub behavior)