### PR TITLE
feat: add status label for 'pinned' and 'stale'

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -94,6 +94,14 @@
   description: Further information is requested
   color: 89cff0
 
+- name: 'status: pinned'
+  description: Exempt from stale/triage automation, never auto-closed
+  color: 0e8a16
+
+- name: 'status: stale'
+  description: No recent activity, candidate for closing
+  color: f6f6f6
+
 - name: 'status: wontfix'
   description: This will not be worked on
   color: ffffff


### PR DESCRIPTION
## What

Adds two new `status:` labels to the org-wide label taxonomy in `.github/labels.yml`:
- `status: pinned` — exempt from stale/triage automation, never auto-closed
- `status: stale` — no recent activity, candidate for closing

## Why

Groundwork for planned issue-triage automation (e.g. wrapping `actions/stale` as a reusable housekeeping job). `status: pinned` protects perpetual issues like Renovate's Dependency Dashboard from ever being marked stale or auto-closed.

## File risk

### 🟢 Low

- `.github/labels.yml` — added `status: pinned` and `status: stale` labels