### PR TITLE
feat: mark issues as stale during housekeeping

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -11,3 +11,8 @@ jobs:
     permissions:
       actions: write
       contents: read
+  stale-issues:
+    name: Mark Stale Issues
+    uses: jfandy1982/shared-github-workflows/.github/workflows/reusable-stale-issues.yml@main
+    permissions:
+      issues: write


### PR DESCRIPTION
## What
Adds a `stale-issues` job to the Housekeeping workflow, calling the reusable `reusable-stale-issues.yml` workflow from `jfandy1982/shared-github-workflows` with `issues: write` permission.

## Why
No motivation evident from commit message or linked issue — follows the existing "lego brick" pattern of wrapping shared reusable workflows as jobs in Housekeeping (consistent with the other job in this file).

## File risk

### 🟡 Medium

- `.github/workflows/housekeeping.yml` — adds stale-issues job calling reusable workflow